### PR TITLE
Replaced `size()` by `length` to support jQuery >= 3.0

### DIFF
--- a/js/bibtexify.js
+++ b/js/bibtexify.js
@@ -2932,7 +2932,7 @@ var bibtexify = (function($) {
                                 'sorting': [[0, "desc"], [1, "desc"]]},
                                 opts);
         var $pubTable = $("#" + bibElemId).addClass("bibtable");
-        if ($("#shutter").size() === 0) {
+        if ($("#shutter").length === 0) {
             $pubTable.before('<div id="shutter" class="hidden"></div>');
             $("#shutter").click(EventHandlers.hidebib);
         }


### PR DESCRIPTION
As pointed out in
https://generatepress.com/forums/topic/implementing-bibtexify/#post-1021497,
`size()` was replaced by `length` in jQuery 3.0 (https://api.jquery.com/size/)