### PR TITLE
Added DOI link/field support - closes issue #2

### DIFF
--- a/js/bibtexify.js
+++ b/js/bibtexify.js
@@ -2607,9 +2607,12 @@ var bibtexify = (function($) {
             if (entryData.url && entryData.url.match(/.*\.pdf/)) {
                 itemStr += ' <a class="bibtexify-link-pdf" target="_blank" title="PDF-version of this article" href="' +
                             entryData.url + '"><\/a>';
+            } else if (entryData.doi && !entryData.url) {
+                itemStr += ' <a class="bibtexify-link-online" target="_blank" title="This article online" href="' +
+                           'https://dx.doi.org/' + entryData.doi + '"><\/a>';
             } else if (entryData.url) {
-                itemStr += ' <a class="bibtexify-link-online" target="_blank" title="This article online" href="' + entryData.url +
-                            '"><\/a>';
+                itemStr += ' <a class="bibtexify-link-online" target="_blank" title="This article online" href="' +
+                           entryData.url + '"><\/a>';
             }
             return itemStr;
         },


### PR DESCRIPTION
This implements DOI link support as requested in #2. Very simple modification which adds an extra if statement looking for `doi` fields in the BiBTeX data and prepending `https://dx.doi.org/` to the `doi` field as well as output a URL in HTML format.